### PR TITLE
CI: run tests on push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,12 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest numpy matplotlib
       - name: Run tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |
-          PYTHONPATH=$GITHUB_WORKSPACE ./venv/bin/pytest -q || PYTHONPATH=$GITHUB_WORKSPACE python -m pytest -q
+          # prefer a project venv if present, otherwise run pytest with PYTHONPATH set
+          if [ -x ./venv/bin/pytest ]; then
+            ./venv/bin/pytest -q
+          else
+            python -m pytest -q
+          fi


### PR DESCRIPTION
Add GitHub Actions workflow to install deps and run pytest on push and pull_request for main/master. Updated to set PYTHONPATH and prefer project venv if present.