### PR TITLE
tests: add CLI parse comma-separated floats test

### DIFF
--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -1,0 +1,9 @@
+from py.cli import parse_ciphertext
+import numpy as np
+
+def test_parse_comma_separated():
+    s = '1.0, -2.0, 3.5'
+    arr = parse_ciphertext(s)
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape[0] == 3
+    assert np.allclose(arr, np.array([1.0, -2.0, 3.5]))


### PR DESCRIPTION
Add unit test to ensure parse_ciphertext handles comma-separated float lists like '1.0, -2.0, 3.5'.